### PR TITLE
v0.2.1: fix .vsix bloat, correct README clone URLs

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -14,12 +14,26 @@ node_modules/**
 # Sourcemaps
 **/*.map
 
-# Dist files the extension doesn't need (CLI, daemon, replay, tests)
+# Dist files the extension doesn't need
+# Only dist/extension.js and dist/webview.js are loaded at runtime.
 dist/cli.js
 dist/daemon_main.js
 dist/replay.js
 dist/tests.js
 dist/wizard.js
+dist/audit_webview.js
+dist/build-harness.js
+dist/debug_dev.js
+dist/gen_audit_harness.js
+dist/gen_fixture.js
+dist/vscode-tests/**
+
+# Test artefacts / dev tooling — never shipped
+coverage/**
+test-results/**
+playwright.config.ts
+posts/**
+.vscode/**
 
 # Local-only state
 .claude/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.2.1]
+
+### Fixed
+
+- **Packaged `.vsix` was bloated.** `.vscodeignore` was missing entries for `coverage/`, `test-results/`, and several stale `dist/` artifacts from older build configurations (`audit_webview.js`, `build-harness.js`, `debug_dev.js`, `gen_audit_harness.js`, `gen_fixture.js`, `dist/vscode-tests/`). The v0.2.0 package shipped at 6.6 MB / 266 files. v0.2.1 ships at 2.4 MB / 12 files containing only what the extension actually loads (`dist/extension.js`, `dist/webview.js`, the schema, screenshots, README, BOOTSTRAP, CHANGELOG, LICENSE, package.json).
+- **README clone URL pointed at the wrong repo.** Three occurrences of `https://github.com/marcusraty/little-oxford.git` corrected to `https://github.com/marcusraty/project-little-oxford.git`. Anyone copy-pasting the clone command from the README in v0.2.0 hit a 404.
+
 ## [0.2.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ When a rule fires, the result fans out to four sinks:
 
 ## Install
 
-Not on the VS Code Marketplace yet. Grab the `.vsix` from the latest [release](https://github.com/marcusraty/little-oxford/releases) (or build it yourself — see [Develop](#develop)).
+Not on the VS Code Marketplace yet. Grab the `.vsix` from the latest [release](https://github.com/marcusraty/project-little-oxford/releases) (or build it yourself — see [Develop](#develop)).
 
 Install it in VS Code:
 
@@ -102,7 +102,7 @@ To **edit or import audit rules later**, click the ⚙ button in the top-right o
 Build from source — clones the repo, installs deps, packages a `.vsix`, and installs it into your VS Code:
 
 ```
-git clone https://github.com/marcusraty/little-oxford.git
+git clone https://github.com/marcusraty/project-little-oxford.git
 cd little-oxford
 npm install
 npm run install:local     # build → npm run package → code --install-extension
@@ -124,7 +124,7 @@ npm run typecheck
 **Debug (F5):** VS Code won't open the same folder in two windows, so use a second clone as a debug workspace.
 
 ```
-git clone https://github.com/marcusraty/little-oxford.git ~/code/little-oxford-debug
+git clone https://github.com/marcusraty/project-little-oxford.git ~/code/little-oxford-debug
 ```
 
 1. Open this repo in your source window.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "little-oxford",
   "displayName": "little-oxford",
   "description": "Render a JSON architecture diagram in VS Code.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "marcusraty",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## What this PR does

Two user-facing bugs from v0.2.0 plus the version metadata to ship them:

- **`.vscodeignore` was missing entries.** `coverage/`, `test-results/`, `playwright.config.ts`, and several stale `dist/` artifacts (`audit_webview.js`, `build-harness.js`, `debug_dev.js`, `gen_audit_harness.js`, `gen_fixture.js`, `dist/vscode-tests/`) were being packaged. v0.2.0 shipped at 6.6 MB / 266 files; v0.2.1 ships at 2.4 MB / 12 files — only `dist/extension.js`, `dist/webview.js`, the schema, README, BOOTSTRAP, CHANGELOG, LICENSE, screenshots, and package.json.
- **README clone URLs pointed at the wrong repo.** Three occurrences of `marcusraty/little-oxford` corrected to `marcusraty/project-little-oxford`. Copy-pasting the clone command from v0.2.0's README hit a 404.
- `package.json` bumped to `0.2.1`.
- `CHANGELOG.md` gets a `[0.2.1]` entry describing both fixes.

## Related issues

Closes #
Refs #

## How I tested it

- [x] `npm run typecheck` passes
- [x] `npm test` passes (532 tests)
- [ ] `npm run test:e2e` passes (if webview changes) — n/a, no webview changes
- [ ] `npm run test:vscode` passes (if extension activation / commands changed) — n/a, no activation changes
- [x] `npm run package` — produces 12-file / 2.29 MB `.vsix` (was 266 files / 6.61 MB)
- [x] Visually checked README at all three clone URL sites — all now point at `project-little-oxford`

## Notes for the reviewer

The `.vscodeignore` change is a whitelist-by-blacklist: I checked `esbuild.config.mjs` entry points and confirmed only `extension.js` and `webview.js` are produced by the current build. Everything else in `dist/` is either old artifacts or test infrastructure. If anything turns out to actually be needed at runtime, integration tests will catch it on the next package — but they pass against the freshly-built bundle.
